### PR TITLE
Provide container with name so that the `docker stop` command works on all computers

### DIFF
--- a/custom_r_inference/custom_r_model_endpoint.ipynb
+++ b/custom_r_inference/custom_r_model_endpoint.ipynb
@@ -93,7 +93,7 @@
    },
    "outputs": [],
    "source": [
-    "!docker run -d --rm -p 5000:8080 r-iris-inference:latest serve"
+    "!docker run -d --rm --name r-iris-inference -p 5000:8080 r-iris-inference:latest serve"
    ]
   },
   {
@@ -131,7 +131,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!docker stop brave_bassi "
+    "!docker stop r-iris-inference "
    ]
   },
   {


### PR DESCRIPTION
*Issue #, if available:*
None. Minor improvement for people following the documentation.

*Description of changes:*
Run Docker container with name so that the stop command works.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
